### PR TITLE
Feature: Generate profile files with compiler detection

### DIFF
--- a/ConanToolWindowControl.xaml
+++ b/ConanToolWindowControl.xaml
@@ -28,7 +28,7 @@
             <Button ToolTip="Configure Conan" Click="Configuration_Click" BorderThickness="0" Background="{x:Null}">
                 <Image Source="./Resources/gear.png" Stretch="None"/>
             </Button>
-            <Button ToolTip="Update package list" Click="ShowPackages_Click" BorderThickness="0" Background="{x:Null}">
+            <Button ToolTip="Show profiles configuration" Click="ShowPackages_Click" BorderThickness="0" Background="{x:Null}">
                 <Image Source="./Resources/eye.png" Stretch="None"/>
             </Button>
             <Button ToolTip="Show used packages" Click="Update_Click" BorderThickness="0" Background="{x:Null}">

--- a/ConanToolWindowControl.xaml.cs
+++ b/ConanToolWindowControl.xaml.cs
@@ -305,10 +305,6 @@ target_link_libraries(your_target_name PRIVATE {cmakeTargetName})
 
         }
 
-        private void ShowPackages_Click(object sender, RoutedEventArgs e)
-        {
-        }
-
         private string getProfileName(string vcConfigName)
         {
             return vcConfigName.Replace("|", "_");

--- a/conan-vs-extension.csproj
+++ b/conan-vs-extension.csproj
@@ -72,6 +72,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.8.2368" />
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>13.0.3</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Page Include="ConanToolWindowControl.xaml">


### PR DESCRIPTION
- Create a dedicated `.conan` folder in projet's root directory.
- Generate a profile for each configuration detected: ``Debug/Release|Win32/x64``.
- ~~Generate a `conan.config.json` file to store the mapping between VS configs and conan profiles.~~
- Get information and convert to Conan values for compiler version (from toolset), build type, and arch ~~(TODO: make the conversion to conan msvc versioning).~~
------
- TODO: Show the generated files to the user when the button is pressed.
- TODO: Change the button icon.