### PR TITLE
Add cppstd detection to profiles

### DIFF
--- a/ConanToolWindowControl.xaml.cs
+++ b/ConanToolWindowControl.xaml.cs
@@ -323,6 +323,13 @@ target_link_libraries(your_target_name PRIVATE {cmakeTargetName})
 
         private string getConanCppstd(string languageStandard)
         {
+            // https://learn.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version?view=msvc-170
+
+            if (languageStandard.ToLower().Contains("default"))
+            {
+                return "14";
+            }
+
             List<string> cppStdValues = new List<string>() { "14", "17", "20", "23" };
 
             foreach (string cppStdValue in cppStdValues)

--- a/ConanToolWindowControl.xaml.cs
+++ b/ConanToolWindowControl.xaml.cs
@@ -321,6 +321,20 @@ target_link_libraries(your_target_name PRIVATE {cmakeTargetName})
             return msvcVersionMap[platformToolset];
         }
 
+        private string getConanCppstd(string languageStandard)
+        {
+            List<string> cppStdValues = new List<string>() { "14", "17", "20", "23" };
+
+            foreach (string cppStdValue in cppStdValues)
+            {
+                if (languageStandard.Contains(cppStdValue))
+                {
+                    return cppStdValue;
+                }
+            }
+            return "null";
+        }
+
         private void ShowPackages_Click(object sender, RoutedEventArgs e)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
@@ -350,8 +364,11 @@ target_link_libraries(your_target_name PRIVATE {cmakeTargetName})
                                     string toolset = vcConfig.Evaluate("$(PlatformToolset)").ToString();
                                     string compilerVersion = getConanCompilerVersion(toolset);
                                     string arch = getConanArch(vcConfig.Evaluate("$(PlatformName)").ToString());
+                                    IVCRulePropertyStorage generalRule = vcConfig.Rules.Item("ConfigurationGeneral") as IVCRulePropertyStorage;
+                                    string languageStandard = generalRule == null ? null : generalRule.GetEvaluatedPropertyValue("LanguageStandard");
+                                    string cppStd = getConanCppstd(languageStandard);
                                     string buildType = vcConfig.ConfigurationName;
-                                    string profileContent = $"[settings]\narch={arch}\nbuild_type={buildType}\ncompiler=msvc\ncompiler.cppstd=14\ncompiler.runtime=dynamic\n" +
+                                    string profileContent = $"[settings]\narch={arch}\nbuild_type={buildType}\ncompiler=msvc\ncompiler.cppstd={cppStd}\ncompiler.runtime=dynamic\n" +
                                         $"compiler.runtime_type={buildType}\ncompiler.version={compilerVersion}\nos=Windows";
                                     File.WriteAllText(profilePath, profileContent);
                                 }


### PR DESCRIPTION
Values from the VS configurations come from:

![image](https://github.com/czoido/conan-vs-extension/assets/10808592/9df79c59-e818-48b2-b8b7-3f12fc3e479e)

And are just the text at the beginning of the value:
- Default
- ISO C++ 14 Standard
- ISO C++ 17 Standard
- ISO C++ 20 Standard
- Preview - Features from the Latest C++ Working Draft