### PR TITLE
More review

### DIFF
--- a/ConanToolWindowControl.xaml
+++ b/ConanToolWindowControl.xaml
@@ -50,7 +50,7 @@
             </TextBlock>
             <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
                 <ComboBox x:Name="VersionsComboBox" Width="150" Margin="5,0" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                <Button x:Name="InstallButton" Content="Install" Margin="5,0" Click="InstallButton_Click" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                <Button x:Name="InstallButton" Content="Add requirement" Margin="5,0" Click="InstallButton_Click" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                 <Button x:Name="RemoveButton" Content="Remove" Margin="5,0" Click="RemoveButton_Click" HorizontalAlignment="Center" VerticalAlignment="Center"/>
             </StackPanel>
             <TextBlock Margin="5,0,5,10">

--- a/ConanToolWindowControl.xaml.cs
+++ b/ConanToolWindowControl.xaml.cs
@@ -190,7 +190,7 @@ namespace conan_vs_extension
             var selectedLibrary = LibraryNameLabel.Content.ToString();
             var selectedVersion = VersionsComboBox.SelectedItem.ToString();
 
-            MessageBox.Show($"Installing {selectedLibrary} version {selectedVersion}", "Conan C/C++ Package Manager");
+            MessageBox.Show($"Requirement {selectedLibrary}/{selectedVersion} added to conandata.yml", "Conan C/C++ Package Manager");
 
             InstallButton.Visibility = Visibility.Collapsed;
             RemoveButton.Visibility = Visibility.Visible;


### PR DESCRIPTION
- improve messages when adding requirements, from install to add requirements
- improve how guarded files are handled, and it should not throw this message any more:
![image](https://github.com/czoido/conan-vs-extension/assets/5045666/f4bf9485-05c4-40e0-b85b-48f3be0ee44b)
